### PR TITLE
Increase retries from 10 to 30 to allow downloading of large activities

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -107,7 +107,7 @@ getVersionString();
 
 enum
 {
-  ANTPM_RETRIES=10,
+  ANTPM_RETRIES=30,
   ANTPM_RETRY_MS=1000,
   ANTPM_MAX_CHANNELS=56
 };


### PR DESCRIPTION
Hello!

I was having problems downloading largish activities from my 910. The watch has been around the block, so it might be getting a little wonky, and requiring several retries when downloading. Unfortunately, it often hits the 10 retry limit.

Allowing more retries made it work.