### PR TITLE
lqueue: avoid infinite loop

### DIFF
--- a/src/lqueue.hpp
+++ b/src/lqueue.hpp
@@ -150,11 +150,10 @@ public:
       {
         //std::cout << "no event before timeout\n";
         //printf("no event before timeout\n");
-        continue;
+        if(Super::m_q.empty())
+          continue; // spurious wakeup
       }
 
-      if(Super::m_q.empty())
-        continue; // spurious wakeup
       size_t s = Super::m_q.size();
       std::vector<DataType> v(s);
       for(size_t i = 0; i < s; i++)
@@ -316,11 +315,10 @@ protected:
       if(std::cv_status::timeout == Super::m_pushEvent.wait_for(lock, Super::td)) // will automatically and atomically unlock mutex while it waits
       {
         //std::cout << "no event before timeout\n";
-        continue;
+        if(Super::m_q.empty())
+          continue; // spurious wakeup
       }
 
-      if(Super::m_q.empty())
-        continue; // spurious wakeup
       size_t s = Super::m_q.size();
       std::vector<DataType> v(s);
       for(size_t i = 0; i < s; i++)


### PR DESCRIPTION
What happens if lqueue3_bg::Super::m_pushEvent.wait_for() is called after the other thread is done with m_pushEvent.notify_all(). In this case the notification we are waiting for never arrives.