### PR TITLE
ci: tidy up in 2026

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,15 +19,12 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-2025
-          - windows-2022
         # https://stackoverflow.com/a/68940067
         compiler: [ {cpp: g++, c: gcc}, {cpp: clang++, c: clang} ]
         exclude:
           - os: macos-latest
             compiler: {cpp: g++, c: gcc}
           - os: windows-2025
-            compiler: {cpp: g++, c: gcc}
-          - os: windows-2022
             compiler: {cpp: g++, c: gcc}
   
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -91,7 +91,7 @@ jobs:
         echo "c:\local\boost_1_87_0\lib64-msvc-14.3" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Configure CMake Unix
       if: runner.os == 'macOS' || runner.os == 'Linux'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,16 +18,12 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - ubuntu-20.04
-          - macos-13
           - windows-2025
           - windows-2022
         # https://stackoverflow.com/a/68940067
         compiler: [ {cpp: g++, c: gcc}, {cpp: clang++, c: clang} ]
         exclude:
           - os: macos-latest
-            compiler: {cpp: g++, c: gcc}
-          - os: macos-13
             compiler: {cpp: g++, c: gcc}
           - os: windows-2025
             compiler: {cpp: g++, c: gcc}

--- a/src/SerialUsb.cpp
+++ b/src/SerialUsb.cpp
@@ -191,7 +191,7 @@ struct SerialUsbPrivate
     ssize_t cnt = libusb_get_device_list(NULL, &list);
     if(cnt < 0)
     {
-      LOG_USB_WARN("libusb_get_device_list", cnt);
+      LOG_USB_WARN("libusb_get_device_list", static_cast<int>(cnt));
       return NULL;
     }
     


### PR DESCRIPTION
Remove disappeared CI runners.
Reduce warnings.